### PR TITLE
Flush stdout from picoquic_sample buffers on newline

### DIFF
--- a/sample/sample_client.c
+++ b/sample/sample_client.c
@@ -524,6 +524,8 @@ int picoquic_sample_client(char const * server_name, char const * cca,
     int server_port, char const * default_dir,
     int nb_files, char const ** file_names)
 {
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     int ret = 0;
     struct sockaddr_storage server_address;
     picoquic_quic_t* quic = NULL;

--- a/sample/sample_server.c
+++ b/sample/sample_server.c
@@ -324,6 +324,8 @@ int sample_server_callback(picoquic_cnx_t* cnx,
 int picoquic_sample_server(int server_port, int nbytes, const char* cca,
                            const char* server_cert, const char* server_key, const char* default_dir)
 {
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
     picoquic_quic_t* quic = NULL;


### PR DESCRIPTION
This makes it possible to use popen with picoquic benchmarks instead of sleeping for a fixed time.